### PR TITLE
Create registration.php

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,5 @@
+<?php
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'IntegerNet_GermanUmlautUrls', __DIR__);


### PR DESCRIPTION
Magento components, including modules, themes, and language packages, must be registered in the Magento system through the Magento ComponentRegistrar class.

https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/component-registration.html